### PR TITLE
WIP: added unit tests and delete skill by id functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ build/
 
 .attach_pid*
 
-app.log
+src/main/resources/logs/**

--- a/src/main/java/com/revature/coi/revanauts/controllers/SkillController.java
+++ b/src/main/java/com/revature/coi/revanauts/controllers/SkillController.java
@@ -11,5 +11,5 @@ public interface SkillController {
 	Skill getSkillByName(String name);
 	Skill addNewSkill(Skill skill);
 	Skill updateSkill(Skill skill);
-
+	void deleteSkillById(long id);
 }

--- a/src/main/java/com/revature/coi/revanauts/controllers/SkillControllerImpl.java
+++ b/src/main/java/com/revature/coi/revanauts/controllers/SkillControllerImpl.java
@@ -3,13 +3,16 @@ package com.revature.coi.revanauts.controllers;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.revature.coi.revanauts.models.Skill;
@@ -46,6 +49,7 @@ public class SkillControllerImpl implements SkillController {
 	}
 
 	@Override
+	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping(produces="application/json", consumes="application/json")
 	public Skill addNewSkill(@RequestBody Skill skill) {
 		return skillService.addNewSkill(skill);
@@ -57,5 +61,10 @@ public class SkillControllerImpl implements SkillController {
 		return skillService.updateSkill(skill);
 	}
 	
+	@Override
+	@DeleteMapping
+	public void deleteSkillById(long id) {
+		skillService.deleteSkillById(id);
+	}
 	
 }

--- a/src/main/java/com/revature/coi/revanauts/models/Skill.java
+++ b/src/main/java/com/revature/coi/revanauts/models/Skill.java
@@ -7,18 +7,26 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import com.sun.istack.NotNull;
+
 @Entity
-@Table(name="SKILL")
+@Table(name = "SKILL")
 public class Skill {
 	
 	@Id
-	@GeneratedValue(strategy=GenerationType.IDENTITY)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	
-	@Column(unique=true)
+	@NotNull
+	@Column(unique = true, nullable = false)
 	private String name;
 	
+	@NotNull
+	@Column(nullable = false)
 	private String description;
+	
+	@NotNull
+	@Column(nullable = false)
 	private String improvementTips;
 	
 	public Skill() {

--- a/src/main/java/com/revature/coi/revanauts/services/SkillService.java
+++ b/src/main/java/com/revature/coi/revanauts/services/SkillService.java
@@ -8,8 +8,9 @@ public interface SkillService {
 	
 	List<Skill> getAllSkills();
 	Skill getSkillById(long id);
-	Skill getSkillByName(String skill);
+	Skill getSkillByName(String skillName);
 	Skill addNewSkill(Skill skill);
 	Skill updateSkill(Skill skill);
+	void deleteSkillById(long id);
 
 }

--- a/src/main/java/com/revature/coi/revanauts/services/SkillServiceImpl.java
+++ b/src/main/java/com/revature/coi/revanauts/services/SkillServiceImpl.java
@@ -72,6 +72,10 @@ public class SkillServiceImpl implements SkillService {
 	@Override
 	public Skill addNewSkill(Skill skill) {
 		
+		if (!isSkillValid(skill)) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid skill object provided in request");
+		}
+		
 		Skill shouldNotExist = skillRepo.findSkillByName(skill.getName());
 		
 		if(shouldNotExist != null) {
@@ -91,10 +95,12 @@ public class SkillServiceImpl implements SkillService {
 	@Override
 	public Skill updateSkill(Skill skill) {
 
-		if(skill.getId() <= 0) {
+		if (skill == null || skill.getId() <= 0 || !isSkillValid(skill)) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid value provided in request");
 		} else if (!skillRepo.findById(skill.getId()).isPresent()) {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No skill found with provided id");
+		} else if (skillRepo.findSkillByName(skill.getName()) == null) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "There is already a skill in the data source with that name.");
 		}
 		
 		Skill updatedSkill = skillRepo.save(skill);
@@ -105,6 +111,25 @@ public class SkillServiceImpl implements SkillService {
 		
 		return updatedSkill;
 		
+	}
+	
+	@Override
+	public void deleteSkillById(long id) {
+		
+		if (id <= 0) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid value provided in request");
+		}
+		
+		skillRepo.deleteById(id);
+		
+	}
+	
+	private boolean isSkillValid(Skill skill) {
+		if (skill == null) return false;
+		if (skill.getName() == null || skill.getName().trim().equals("")) return false;
+		if (skill.getDescription() == null || skill.getDescription().trim().equals("")) return false;
+		if (skill.getImprovementTips() == null || skill.getImprovementTips().trim().equals("")) return false;
+		return true;
 	}
 
 }

--- a/src/test/java/com/revature/coi/revanauts/tests/integration/FeedbackControllerTest.java
+++ b/src/test/java/com/revature/coi/revanauts/tests/integration/FeedbackControllerTest.java
@@ -1,4 +1,4 @@
-package com.revature.coi.revanauts;
+package com.revature.coi.revanauts.tests.integration;
 
 import static io.restassured.RestAssured.get;
 import static io.restassured.RestAssured.with;

--- a/src/test/java/com/revature/coi/revanauts/tests/integration/SkillControllerTest.java
+++ b/src/test/java/com/revature/coi/revanauts/tests/integration/SkillControllerTest.java
@@ -1,4 +1,4 @@
-package com.revature.coi.revanauts;
+package com.revature.coi.revanauts.tests.integration;
 
 import static io.restassured.RestAssured.get;
 import static io.restassured.RestAssured.with;

--- a/src/test/java/com/revature/coi/revanauts/tests/unit/SkillServiceTest.java
+++ b/src/test/java/com/revature/coi/revanauts/tests/unit/SkillServiceTest.java
@@ -1,0 +1,224 @@
+package com.revature.coi.revanauts.tests.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.calls;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.revature.coi.revanauts.models.Skill;
+import com.revature.coi.revanauts.repos.SkillRepository;
+import com.revature.coi.revanauts.services.SkillService;
+import com.revature.coi.revanauts.services.SkillServiceImpl;
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class SkillServiceTest {
+
+	@Mock
+	private SkillRepository mockSkillRepo;
+	
+	@InjectMocks
+	private SkillService sut = new SkillServiceImpl(mockSkillRepo);
+	
+	private Skill mockValidSkill;
+	
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+		mockValidSkill = new Skill(1L, "test skill", "test skill", "test skill");
+	}
+	
+	@Test
+	public void getAllSkillsWhenSkillsAreFoundTest() {
+		List<Skill> expectedResult = new ArrayList<>();
+		expectedResult.add(mockValidSkill);
+		when(mockSkillRepo.findAll()).thenReturn(expectedResult);
+		List<Skill> actualResult = sut.getAllSkills();
+		verify(mockSkillRepo, times(1)).findAll();
+		assertEquals(expectedResult, actualResult);
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void getAllSkillsWhenSkillsAreNotFoundTest() {
+		when(mockSkillRepo.findAll()).thenReturn(new ArrayList<>());
+		sut.getAllSkills();
+		verify(mockSkillRepo, times(1)).findAll();
+	}
+	
+	@Test
+	public void getSkillByValidAndKnownId() {
+		Skill expectedResult = new Skill(1L, "test skill", "test skill", "test skill");
+		when(mockSkillRepo.findById(1L)).thenReturn(Optional.of(expectedResult));
+		Skill actualResult = sut.getSkillById(1L);
+		verify(mockSkillRepo, times(1)).findById(1L);
+		assertEquals(expectedResult, actualResult);
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void getSkillByValidAndUnknownId() {
+		when(mockSkillRepo.findById(10000L)).thenReturn(Optional.empty());
+		sut.getSkillById(10000L);
+		verify(mockSkillRepo, calls(1)).findById(10000L);
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void getSkillByInvalidId() {
+		sut.getSkillById(-1L);
+		verify(mockSkillRepo, never()).findById(Mockito.anyLong());
+	}
+	
+	@Test
+	public void getSkillByValidAndKnownName() {
+		Skill expectedResult = new Skill(1L, "test skill", "test skill", "test skill");
+		when(mockSkillRepo.findSkillByName(Mockito.anyString())).thenReturn(expectedResult);
+		Skill actualResult = sut.getSkillByName("test skill");
+		verify(mockSkillRepo, times(1)).findSkillByName("test skill");
+		assertEquals(expectedResult, actualResult);
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void getSkillByValidAndUnknownName() {
+		when(mockSkillRepo.findSkillByName(Mockito.anyString())).thenReturn(null);
+		sut.getSkillByName("fake skill");
+		verify(mockSkillRepo, times(1)).findSkillByName("fake skill");
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void getSkillByNullName() {
+		when(mockSkillRepo.findById(-1L)).thenReturn(Optional.empty());
+		sut.getSkillById(-1L);
+		verify(mockSkillRepo, never()).findSkillByName(Mockito.anyString());
+	}
+	
+	@Test
+	public void addNewValidSkillNotDuplicateTest() {
+		Skill expectedResult = mockValidSkill;
+		Skill newValidSkill = new Skill(0L, "test skill", "test skill", "test skill");
+		when(mockSkillRepo.findSkillByName(Mockito.anyString())).thenReturn(null);
+		when(mockSkillRepo.save(newValidSkill)).thenReturn(expectedResult);
+		Skill actualResult = sut.addNewSkill(newValidSkill);
+		verify(mockSkillRepo, times(1)).save(Mockito.any());
+		assertEquals(expectedResult, actualResult);
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void addNewValidSkillDuplicateNameTest() {
+		Skill duplicateValidSkill = new Skill(0L, "test skill", "test skill", "test skill");
+		when(mockSkillRepo.findSkillByName(Mockito.anyString())).thenReturn(mockValidSkill);
+		sut.addNewSkill(duplicateValidSkill);
+		verify(mockSkillRepo, times(1)).save(Mockito.any());
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void addNewInvalidSkillWithNullNameTest() {
+		Skill invalidSkill = new Skill(0L, null, "test skill", "test skill");
+		sut.addNewSkill(invalidSkill);
+		verify(mockSkillRepo, never()).save(Mockito.any());
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void addNewInvalidSkillWithNullDescriptionTest() {
+		Skill invalidSkill = new Skill(0L, "test skill", null, "test skill");
+		sut.addNewSkill(invalidSkill);
+		verify(mockSkillRepo, never()).save(Mockito.any());
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void addNewInvalidSkillWithNullTipsTest() {
+		Skill invalidSkill = new Skill(0L, "test skill", "test skill", null);
+		sut.addNewSkill(invalidSkill);
+		verify(mockSkillRepo, never()).save(Mockito.any());
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void addNewNullSkillTest() {
+		sut.addNewSkill(null);
+		verify(mockSkillRepo, times(1)).save(Mockito.any());
+	}
+	
+	@Test
+	public void updateExistingSkillWithValidSkillNotDuplicateTest() {
+		Skill expectedResult = new Skill(1L, "updated skill", "test skill", "test skill");
+		Skill updatedValidSkill = new Skill(1L, "updated skill", "test skill", "test skill");
+		when(mockSkillRepo.findById(1L)).thenReturn(Optional.of(mockValidSkill));
+		when(mockSkillRepo.findSkillByName(Mockito.anyString())).thenReturn(null);
+		when(mockSkillRepo.save(updatedValidSkill)).thenReturn(expectedResult);
+		Skill actualResult = sut.addNewSkill(updatedValidSkill);
+		verify(mockSkillRepo, times(1)).save(Mockito.any());
+		assertEquals(expectedResult, actualResult);
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void updateExistingValidSkillWithDuplicateNameTest() {
+		Skill updatedValidSkillDuplicateName = new Skill(1L, "test skill", "test skill", "test skill");
+		when(mockSkillRepo.findById(1L)).thenReturn(Optional.of(mockValidSkill));
+		when(mockSkillRepo.findSkillByName(Mockito.anyString())).thenReturn(mockValidSkill);
+		sut.addNewSkill(updatedValidSkillDuplicateName);
+		verify(mockSkillRepo, times(1)).save(Mockito.any());
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void updateSkillWithInvalidSkillId() {
+		Skill invalidSkill = new Skill(0L, "test skill", "test skill", "test skill");
+		sut.updateSkill(invalidSkill);
+		verify(mockSkillRepo, never()).save(Mockito.any());
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void updateExistingSkillWithNullNameTest() {
+		Skill invalidSkill = new Skill(1L, null, "test skill", "test skill");
+		sut.updateSkill(invalidSkill);
+		verify(mockSkillRepo, never()).save(Mockito.any());
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void updateExistingSkillWithNullDescriptionTest() {
+		Skill invalidSkill = new Skill(0L, "test skill", null, "test skill");
+		sut.updateSkill(invalidSkill);
+		verify(mockSkillRepo, never()).save(Mockito.any());
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void updateExistingSkillWithNullTipsTest() {
+		Skill invalidSkill = new Skill(0L, "test skill", "test skill", null);
+		sut.updateSkill(invalidSkill);
+		verify(mockSkillRepo, never()).save(Mockito.any());
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void updateSkillWithNullSkillTest() {
+		sut.updateSkill(null);
+		verify(mockSkillRepo, never()).save(Mockito.any());
+	}
+	
+	@Test
+	public void deleteSkillWithValidId() {
+		sut.deleteSkillById(1L);
+		verify(mockSkillRepo, times(1)).deleteById(Mockito.anyLong());
+	}
+	
+	@Test(expected = ResponseStatusException.class)
+	public void deleteSkillWithInvalidId() {
+		sut.deleteSkillById(-1L);
+		verify(mockSkillRepo, never()).deleteById(Mockito.anyLong());
+	}
+	
+}

--- a/src/test/java/com/revature/coi/revanauts/tests/unit/SkillServiceTest.java
+++ b/src/test/java/com/revature/coi/revanauts/tests/unit/SkillServiceTest.java
@@ -2,7 +2,6 @@ package com.revature.coi.revanauts.tests.unit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.calls;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
changes in this PR:

- added JSR 303 annotations and JPA column constraints to Skill model
- added functionality for delete by id
- added unit tests for SkillServiceImpl

things that still need to be address before merging:

- RestAssured integration tests fail inconsistently due to application context failing to load, exception method points to failure to execute sql statements in data.sql due to integrity violation constraints; I've not had much luck in identifying the problem - perhaps someone else could assist